### PR TITLE
Add WireBeGone and VRLogixRotateFix

### DIFF
--- a/LogixUtils/LogixUtils.cs
+++ b/LogixUtils/LogixUtils.cs
@@ -11,7 +11,7 @@ namespace LogixUtils
     {
         public override string Name => "LogixUtils";
         public override string Author => "badhaloninja";
-        public override string Version => "1.6.0";
+        public override string Version => "1.7.0";
         public override string Link => "https://github.com/badhaloninja/LogixUtils";
 
         internal static ModConfiguration config;
@@ -57,6 +57,12 @@ namespace LogixUtils
         public static readonly ModConfigurationKey<Key> AlignScaleModifierKey = new ModConfigurationKey<Key>("alignScaleModifierKey", "Key to be held to allow scaling on align", () => Key.Space);
         [AutoRegisterConfigKey]
         public static readonly ModConfigurationKey<bool> ModifiedScaleToUserScale = new ModConfigurationKey<bool>("modifiedScaleToUserScale", "Scale to user scale when aligning scale instead of global 1", () => false);
+        
+        [AutoRegisterConfigKey]
+        public static readonly ModConfigurationKey<bool> AlignNodeRotationToUserVr = new ModConfigurationKey<bool>("alignNodeRotationToUserVr", "Aligns the spawned node to be same rotation as user while in VR", () => true);
+
+        [AutoRegisterConfigKey]
+        public static readonly ModConfigurationKey<bool> RemoveWireToTargetSlot = new ModConfigurationKey<bool>("RemoveWireToTargetSlot", "De-activates the wire connecting a LogiX Interface to its target", () => true);
 
 
 
@@ -68,7 +74,9 @@ namespace LogixUtils
             { ExtractRefOfAny, new ExtractRef() },
             { ClampNodeTextures, new ClampNodes() },
             { AddInputNodes, new InputNodes() },
-            { RepairCrashedNodesContext, new TryRepairNodes() }
+            { RepairCrashedNodesContext, new TryRepairNodes() },
+            { AlignNodeRotationToUserVr, new VrSpawnFix() },
+            { RemoveWireToTargetSlot, new WireBeGone() }
         };
 
         public override void OnEngineInit()

--- a/LogixUtils/LogixUtils.cs
+++ b/LogixUtils/LogixUtils.cs
@@ -59,10 +59,10 @@ namespace LogixUtils
         public static readonly ModConfigurationKey<bool> ModifiedScaleToUserScale = new ModConfigurationKey<bool>("modifiedScaleToUserScale", "Scale to user scale when aligning scale instead of global 1", () => false);
         
         [AutoRegisterConfigKey]
-        public static readonly ModConfigurationKey<bool> AlignNodeRotationToUserVr = new ModConfigurationKey<bool>("alignNodeRotationToUserVr", "Aligns the spawned node to be same rotation as user while in VR", () => true);
+        public static readonly ModConfigurationKey<bool> AlignNodeRotationToUserVr = new ModConfigurationKey<bool>("alignNodeRotationToUserVr", "Aligns the spawned nodes to the user's up", () => true);
 
         [AutoRegisterConfigKey]
-        public static readonly ModConfigurationKey<bool> RemoveWireToTargetSlot = new ModConfigurationKey<bool>("RemoveWireToTargetSlot", "De-activates the wire connecting a LogiX Interface to its target", () => true);
+        public static readonly ModConfigurationKey<bool> AddWireToggleButton = new ModConfigurationKey<bool>("addWireToggleButton", "Adds a button to interfaces that toggles the wire, the wire is defaulted to off", () => true);
 
 
 
@@ -76,7 +76,7 @@ namespace LogixUtils
             { AddInputNodes, new InputNodes() },
             { RepairCrashedNodesContext, new TryRepairNodes() },
             { AlignNodeRotationToUserVr, new VrSpawnFix() },
-            { RemoveWireToTargetSlot, new WireBeGone() }
+            { AddWireToggleButton, new WireBeGone() }
         };
 
         public override void OnEngineInit()

--- a/LogixUtils/LogixUtils.csproj
+++ b/LogixUtils/LogixUtils.csproj
@@ -13,6 +13,7 @@
     <NeosPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\NeosVR\')">C:\Program Files (x86)\Steam\steamapps\common\NeosVR\</NeosPath>
     <NeosPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/NeosVR/')">$(HOME)/.steam/steam/steamapps/common/NeosVR/</NeosPath>
     <NeosPath Condition="Exists('E:\Programs\Steam\steamapps\common\NeosVR\')">E:\Programs\Steam\steamapps\common\NeosVR\</NeosPath>
+    <NeosPath Condition="Exists('D:\Apps\Neos\app\')">D:\Apps\Neos\app\</NeosPath>
     <CopyLocal>false</CopyLocal>
     <CopyToMods Condition="'$(CopyToMods)'==''">true</CopyToMods>
     <DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>

--- a/LogixUtils/Patches/VrSpawnFix.cs
+++ b/LogixUtils/Patches/VrSpawnFix.cs
@@ -1,0 +1,36 @@
+﻿using FrooxEngine;
+using FrooxEngine.LogiX;
+using HarmonyLib;
+using System.Reflection;
+
+namespace LogixUtils
+{
+    class VrSpawnFix : ToggleablePatch
+    {
+        public override void Patch(Harmony harmony, LogixUtils mod)
+        {
+            var positionSpawnedNodeMethod = typeof(LogixTip).GetMethod("PositionSpawnedNode", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var vrNodeRotationPatchMethod = typeof(VrSpawnFix).GetMethod("VrNodeRotationPatch");
+
+            harmony.Patch(positionSpawnedNodeMethod, postfix: new HarmonyMethod(vrNodeRotationPatchMethod));
+        }
+
+        public override void Unpatch(Harmony harmony, LogixUtils mod)
+        {
+            var positionSpawnedNodeMethod = typeof(LogixTip).GetMethod("PositionSpawnedNode", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var vrNodeRotationPatchMethod = typeof(VrSpawnFix).GetMethod("VrNodeRotationPatch");
+
+            harmony.Unpatch(positionSpawnedNodeMethod, vrNodeRotationPatchMethod);
+        }
+
+        public static void VrNodeRotationPatch(LogixTip __instance, Slot node)
+        {
+            if (__instance.InputInterface.VR_Active)
+            {
+                node.Up = __instance.Slot.ActiveUserRoot.Slot.Up;
+            }
+        }
+    }
+}

--- a/LogixUtils/Patches/WireBeGone.cs
+++ b/LogixUtils/Patches/WireBeGone.cs
@@ -28,24 +28,22 @@ namespace LogixUtils
 
         public static void wireBeGonePatch(Slot __result)
         {
-            Slot toggleRoot = __result[0]?.Find("WireToggle");
+            Slot toggleRoot = __result[0]?.FindInChildren("WireToggle");
             if (toggleRoot != null) return;
 
             var wire = __result.GetComponentInChildren<ConnectionWire>(c => c.Slot.Name.Equals("LinkPoint"));
             if (wire == null) return;
 
-
             UIBuilder ui = new UIBuilder(wire.Slot.Parent);
-
 
             var toggleButton = ui.Button("");
             toggleButton.Slot.Name = "WireToggle";
-            toggleButton.RectTransform.OffsetMax.Value = new BaseX.float2(-122, 0);
+            toggleButton.RectTransform.OffsetMax.Value = new BaseX.float2(-112, 0);
             
             toggleButton.LabelTextField.DriveFromBool(wire.Slot.ActiveSelf_Field, "⦿", "◌");
             toggleButton.Slot.AttachComponent<ButtonToggle>().TargetValue.TrySet(wire.Slot.ActiveSelf_Field);
-            wire.Slot.ActiveSelf_Field.GetUserOverride(true).Default.Value = false;
 
+            wire.Slot.ActiveSelf_Field.GetUserOverride(true).Default.Value = false;
             wire.Slot.Parent = toggleButton.Slot;
         }
     }

--- a/LogixUtils/Patches/WireBeGone.cs
+++ b/LogixUtils/Patches/WireBeGone.cs
@@ -1,5 +1,6 @@
 ﻿using FrooxEngine;
 using FrooxEngine.LogiX;
+using FrooxEngine.UIX;
 using HarmonyLib;
 using System.Reflection;
 
@@ -9,7 +10,7 @@ namespace LogixUtils
     {
         public override void Patch(Harmony harmony, LogixUtils mod)
         {
-            var onAttachMethod = typeof(ConnectionWire).GetMethod("OnAttach", BindingFlags.NonPublic | BindingFlags.Instance);
+            var onAttachMethod = typeof(LogixInterfaceProxy).GetMethod("GetInterface", BindingFlags.Public | BindingFlags.Instance);
 
             var wireBeGonePatchMethod = typeof(WireBeGone).GetMethod("wireBeGonePatch");
 
@@ -18,19 +19,34 @@ namespace LogixUtils
 
         public override void Unpatch(Harmony harmony, LogixUtils mod)
         {
-            var onAttachMethod = typeof(ConnectionWire).GetMethod("OnAttach", BindingFlags.NonPublic | BindingFlags.Instance);
+            var onAttachMethod = typeof(LogixInterfaceProxy).GetMethod("GetInterface", BindingFlags.Public | BindingFlags.Instance);
 
             var wireBeGonePatchMethod = typeof(WireBeGone).GetMethod("wireBeGonePatch");
 
             harmony.Unpatch(onAttachMethod, wireBeGonePatchMethod);
         }
 
-        public static void wireBeGonePatch(ConnectionWire __instance)
+        public static void wireBeGonePatch(Slot __result)
         {
-            if (__instance.Slot.Name.Equals("LinkPoint"))
-            {
-                __instance.Slot.ActiveSelf = false;
-            }
+            Slot toggleRoot = __result[0]?.Find("WireToggle");
+            if (toggleRoot != null) return;
+
+            var wire = __result.GetComponentInChildren<ConnectionWire>(c => c.Slot.Name.Equals("LinkPoint"));
+            if (wire == null) return;
+
+
+            UIBuilder ui = new UIBuilder(wire.Slot.Parent);
+
+
+            var toggleButton = ui.Button("");
+            toggleButton.Slot.Name = "WireToggle";
+            toggleButton.RectTransform.OffsetMax.Value = new BaseX.float2(-122, 0);
+            
+            toggleButton.LabelTextField.DriveFromBool(wire.Slot.ActiveSelf_Field, "⦿", "◌");
+            toggleButton.Slot.AttachComponent<ButtonToggle>().TargetValue.TrySet(wire.Slot.ActiveSelf_Field);
+            wire.Slot.ActiveSelf_Field.GetUserOverride(true).Default.Value = false;
+
+            wire.Slot.Parent = toggleButton.Slot;
         }
     }
 }

--- a/LogixUtils/Patches/WireBeGone.cs
+++ b/LogixUtils/Patches/WireBeGone.cs
@@ -1,0 +1,36 @@
+﻿using FrooxEngine;
+using FrooxEngine.LogiX;
+using HarmonyLib;
+using System.Reflection;
+
+namespace LogixUtils
+{
+    class WireBeGone : ToggleablePatch
+    {
+        public override void Patch(Harmony harmony, LogixUtils mod)
+        {
+            var onAttachMethod = typeof(ConnectionWire).GetMethod("OnAttach", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var wireBeGonePatchMethod = typeof(WireBeGone).GetMethod("wireBeGonePatch");
+
+            harmony.Patch(onAttachMethod, postfix: new HarmonyMethod(wireBeGonePatchMethod));
+        }
+
+        public override void Unpatch(Harmony harmony, LogixUtils mod)
+        {
+            var onAttachMethod = typeof(ConnectionWire).GetMethod("OnAttach", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var wireBeGonePatchMethod = typeof(WireBeGone).GetMethod("wireBeGonePatch");
+
+            harmony.Unpatch(onAttachMethod, wireBeGonePatchMethod);
+        }
+
+        public static void wireBeGonePatch(ConnectionWire __instance)
+        {
+            if (__instance.Slot.Name.Equals("LinkPoint"))
+            {
+                __instance.Slot.ActiveSelf = false;
+            }
+        }
+    }
+}

--- a/LogixUtils/Properties/AssemblyInfo.cs
+++ b/LogixUtils/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.7.0.0")]
+[assembly: AssemblyFileVersion("1.7.0.0")]

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ All features are toggleable in the config, most are on by default
 ### Current features: 
  - Scales relays, drives, casts, and reference nodes relative to user
  - Updates `LogixHelper.GetNodeName` to display generic type names nicer
- - Allows aligning logix to snapped angles with the UI_TargettingController
- - Changes Extract Ref Node to allow any refrence instead of only IField
+ - Allows aligning logix to snapped angles with the UI_TargetingController
+ - Changes Extract Ref Node to allow any reference instead of only IField
  - Allows spawning a Value/Reference register from a Write node target
  - Sets various logix node textures to clamp
- - Adds a repair crashed nodes contex menu item to the logix tip when holding a slot with crashed nodes under it
+ - Adds a repair crashed nodes context menu item to the logix tip when holding a slot with crashed nodes under it
+ - Allows spawning Logix node at the same rotation as the user
+ - Allows the deactivation of the Link wire from Logix Interfaces to their target
 
 ## Installation
 1. Install [NeosModLoader](https://github.com/zkxs/NeosModLoader).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All features are toggleable in the config, most are on by default
  - Allows spawning a Value/Reference register from a Write node target
  - Sets various logix node textures to clamp
  - Adds a repair crashed nodes context menu item to the logix tip when holding a slot with crashed nodes under it
- - Allows spawning Logix node at the same rotation as the user
+ - Allows spawning Logix node at the same rotation as the user when in VR
  - Allows the deactivation of the Link wire from Logix Interfaces to their target
 
 ## Installation


### PR DESCRIPTION
Hi,

I've added my mod [VRLogixRotateFix](https://github.com/AlexW-578/VRLogixRotateFix) and a new mod called WireBeGone as patches.

WireBeGone allows the user to deactivate the wire connecting the Logix Interface to their target.
VRLogixRotateFix allows spawning Logix node at the same rotation as the user when in VR

